### PR TITLE
refactor: Move from Lazy to OnceCell

### DIFF
--- a/crates/libtest2-mimic/tests/testsuite/all_passing.rs
+++ b/crates/libtest2-mimic/tests/testsuite/all_passing.rs
@@ -1,8 +1,9 @@
 fn test_cmd() -> snapbox::cmd::Command {
-    static BIN: once_cell::sync::Lazy<(std::path::PathBuf, std::path::PathBuf)> =
-        once_cell::sync::Lazy::new(|| {
-            let package_root = crate::util::new_test(
-                r#"
+    static BIN: once_cell::sync::OnceCell<(std::path::PathBuf, std::path::PathBuf)> =
+        once_cell::sync::OnceCell::new();
+    let (bin, current_dir) = BIN.get_or_init(|| {
+        let package_root = crate::util::new_test(
+            r#"
 fn main() {
     use libtest2_mimic::Trial;
     libtest2_mimic::Harness::with_env()
@@ -14,12 +15,12 @@ fn main() {
         .main();
 }
 "#,
-                false,
-            );
-            let bin = crate::util::compile_test(&package_root);
-            (bin, package_root)
-        });
-    snapbox::cmd::Command::new(&BIN.0).current_dir(&BIN.1)
+            false,
+        );
+        let bin = crate::util::compile_test(&package_root);
+        (bin, package_root)
+    });
+    snapbox::cmd::Command::new(bin).current_dir(current_dir)
 }
 
 fn check(args: &[&str], single: &str, parallel: &str) {

--- a/crates/libtest2-mimic/tests/testsuite/mixed_bag.rs
+++ b/crates/libtest2-mimic/tests/testsuite/mixed_bag.rs
@@ -1,8 +1,9 @@
 fn test_cmd() -> snapbox::cmd::Command {
-    static BIN: once_cell::sync::Lazy<(std::path::PathBuf, std::path::PathBuf)> =
-        once_cell::sync::Lazy::new(|| {
-            let package_root = crate::util::new_test(
-                r#"
+    static BIN: once_cell::sync::OnceCell<(std::path::PathBuf, std::path::PathBuf)> =
+        once_cell::sync::OnceCell::new();
+    let (bin, current_dir) = BIN.get_or_init(|| {
+        let package_root = crate::util::new_test(
+            r#"
 fn main() {
     use libtest2_mimic::Trial;
     use libtest2_mimic::RunError;
@@ -35,12 +36,12 @@ fn main() {
         .main();
 }
 "#,
-                false,
-            );
-            let bin = crate::util::compile_test(&package_root);
-            (bin, package_root)
-        });
-    snapbox::cmd::Command::new(&BIN.0).current_dir(&BIN.1)
+            false,
+        );
+        let bin = crate::util::compile_test(&package_root);
+        (bin, package_root)
+    });
+    snapbox::cmd::Command::new(bin).current_dir(current_dir)
 }
 
 fn check(args: &[&str], code: i32, single: &str, parallel: &str) {

--- a/crates/libtest2-mimic/tests/testsuite/panic.rs
+++ b/crates/libtest2-mimic/tests/testsuite/panic.rs
@@ -1,8 +1,9 @@
 fn test_cmd() -> snapbox::cmd::Command {
-    static BIN: once_cell::sync::Lazy<(std::path::PathBuf, std::path::PathBuf)> =
-        once_cell::sync::Lazy::new(|| {
-            let package_root = crate::util::new_test(
-                r#"
+    static BIN: once_cell::sync::OnceCell<(std::path::PathBuf, std::path::PathBuf)> =
+        once_cell::sync::OnceCell::new();
+    let (bin, current_dir) = BIN.get_or_init(|| {
+        let package_root = crate::util::new_test(
+            r#"
 fn main() {
     use libtest2_mimic::Trial;
     libtest2_mimic::Harness::with_env()
@@ -13,12 +14,12 @@ fn main() {
         .main();
 }
 "#,
-                false,
-            );
-            let bin = crate::util::compile_test(&package_root);
-            (bin, package_root)
-        });
-    snapbox::cmd::Command::new(&BIN.0).current_dir(&BIN.1)
+            false,
+        );
+        let bin = crate::util::compile_test(&package_root);
+        (bin, package_root)
+    });
+    snapbox::cmd::Command::new(bin).current_dir(current_dir)
 }
 
 fn check(args: &[&str], code: i32, single: &str, parallel: &str) {

--- a/crates/libtest2/tests/testsuite/all_passing.rs
+++ b/crates/libtest2/tests/testsuite/all_passing.rs
@@ -1,8 +1,9 @@
 fn test_cmd() -> snapbox::cmd::Command {
-    static BIN: once_cell::sync::Lazy<(std::path::PathBuf, std::path::PathBuf)> =
-        once_cell::sync::Lazy::new(|| {
-            let package_root = crate::util::new_test(
-                r#"
+    static BIN: once_cell::sync::OnceCell<(std::path::PathBuf, std::path::PathBuf)> =
+        once_cell::sync::OnceCell::new();
+    let (bin, current_dir) = BIN.get_or_init(|| {
+        let package_root = crate::util::new_test(
+            r#"
 libtest2::libtest2_main!(foo, bar, barro);
 
 fn foo(_state: &libtest2::State) -> libtest2::RunResult {
@@ -17,12 +18,12 @@ fn barro(_state: &libtest2::State) -> libtest2::RunResult {
     Ok(())
 }
 "#,
-                false,
-            );
-            let bin = crate::util::compile_test(&package_root);
-            (bin, package_root)
-        });
-    snapbox::cmd::Command::new(&BIN.0).current_dir(&BIN.1)
+            false,
+        );
+        let bin = crate::util::compile_test(&package_root);
+        (bin, package_root)
+    });
+    snapbox::cmd::Command::new(bin).current_dir(current_dir)
 }
 
 fn check(args: &[&str], single: &str, parallel: &str) {

--- a/crates/libtest2/tests/testsuite/panic.rs
+++ b/crates/libtest2/tests/testsuite/panic.rs
@@ -1,8 +1,9 @@
 fn test_cmd() -> snapbox::cmd::Command {
-    static BIN: once_cell::sync::Lazy<(std::path::PathBuf, std::path::PathBuf)> =
-        once_cell::sync::Lazy::new(|| {
-            let package_root = crate::util::new_test(
-                r#"
+    static BIN: once_cell::sync::OnceCell<(std::path::PathBuf, std::path::PathBuf)> =
+        once_cell::sync::OnceCell::new();
+    let (bin, current_dir) = BIN.get_or_init(|| {
+        let package_root = crate::util::new_test(
+            r#"
 libtest2::libtest2_main!(passes, panics);
 
 fn passes(_state: &libtest2::State) -> libtest2::RunResult {
@@ -13,12 +14,12 @@ fn panics(_state: &libtest2::State) -> libtest2::RunResult {
     panic!("uh oh")
 }
 "#,
-                false,
-            );
-            let bin = crate::util::compile_test(&package_root);
-            (bin, package_root)
-        });
-    snapbox::cmd::Command::new(&BIN.0).current_dir(&BIN.1)
+            false,
+        );
+        let bin = crate::util::compile_test(&package_root);
+        (bin, package_root)
+    });
+    snapbox::cmd::Command::new(bin).current_dir(current_dir)
 }
 
 fn check(args: &[&str], code: i32, single: &str, parallel: &str) {


### PR DESCRIPTION
This is prep for exploring a way to drop once_cell without an MSRV bump